### PR TITLE
Restructure README to be use-case focused

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,203 +1,269 @@
 # req
 
-**req** is a command-line tool for sending http request.
+**req** is a command-line tool for managing and executing HTTP requests using configuration files.
 
-## Basic Usage
+## Why req?
 
-Request tasks are defined in a file usually named `req.toml`. For example:
+Have you ever needed to:
+- Test API endpoints repeatedly during development?
+- Share API request configurations with your team?
+- Manage different environments (dev, staging, prod) for the same API?
+- Document API usage in a simple, executable format?
 
-```toml
-[tasks.get]
-GET = 'https://httpbin.org/get'
-description = "GET request"
+**req** solves these problems by letting you define HTTP requests in a TOML file and execute them with a simple command.
 
-[tasks.post]
-POST = 'https://httpbin.org/post'
-description = "POST request"
-```
+## Quick Start
 
-To send request, run `req` command with task name:
+### Installation
 
 ```shell
-$ req get
-# => GET https://httpbin.org/get
-
-$ req post
-# => POST https://httpbin.org/post
+cargo install req
 ```
 
-Without task name, `req` prints list of tasks:
+### Your First Request
+
+Create a file named `req.toml`:
+
+```toml
+[tasks.hello]
+GET = 'https://httpbin.org/get'
+description = "My first request"
+```
+
+Run it:
+
+```shell
+$ req hello
+# Sends GET request to https://httpbin.org/get
+```
+
+That's it! You've just sent your first HTTP request with req.
+
+## Common Use Cases
+
+### 1. Testing REST APIs
+
+Create a set of tasks for your API endpoints:
+
+```toml
+[tasks.list-users]
+GET = 'https://api.example.com/users'
+description = "Get all users"
+
+[tasks.get-user]
+GET = 'https://api.example.com/users/123'
+description = "Get specific user"
+
+[tasks.create-user]
+POST = 'https://api.example.com/users'
+description = "Create new user"
+
+[tasks.create-user.body.json]
+name = "John Doe"
+email = "john@example.com"
+```
+
+List all available tasks:
 
 ```shell
 $ req
-get     GET request
-post    POST request
+list-users    Get all users
+get-user      Get specific user
+create-user   Create new user
 ```
 
-## CLI Options
-
-### -h, --help
-
-Print help information.
-
-### -V, --version
-
-Print version information.
-
-### -f, --file `<DEF>`
-
-Read task definitions from `<DEF>`. (default: `req.toml`)
-
-### -i, --include-header
-
-Include response headers in the output
-
-### -v, --var
-
-Pass variable in the form `KEY=VALUE`.
-This option can be specified multple times.
-
-### --dryrun
-
-Dump internal structure of specified task without sending request.
+Execute any task:
 
 ```shell
-$ req get --dryrun
-ReqTask {
-    method: Get(
-        "https://httpbin.org/get",
-    ),
-    headers: {},
-    queries: {},
-    body: Plain(
-        "",
-    ),
-    description: "GET request",
-    config: None,
-}
+$ req list-users
+$ req create-user
 ```
 
-### [experimental] --curl
+### 2. Working with Authentication
 
-Print compatible curl command. _This feature may not perform stably._
-
-```
-$ req get --curl
-curl -X GET 'https://httpbin.org/get'
-```
-
-## Configuration
-
-### tasks.{NAME}
-
-Define a task named `{NAME}`.
-
-### tasks.{NAME}.description
-
-Speify description for the task.
-
-### tasks.{NAME}.GET = {URL}
-
-### tasks.{NAME}.POST = {URL}
-
-### tasks.{NAME}.PUT = {URL}
-
-### tasks.{NAME}.DELETE = {URL}
-
-### tasks.{NAME}.HEAD = {URL}
-
-### tasks.{NAME}.OPTIONS = {URL}
-
-### tasks.{NAME}.CONNECT = {URL}
-
-### tasks.{NAME}.PATCH = {URL}
-
-### tasks.{NAME}.TRACE = {URL}
-
-Specify HTTP method and URL to send request.
-
-### tasks.{NAME}.headers = {TABLE}
-
-### tasks.{NAME}.queries = {TABLE}
-
-Specify headers and queries as table to be given to request.
-Values of these table should be string or array of string.
-
-### tasks.{NAME}.body.plain = {TEXT}
-
-Specify request plain text body with `Content-Type: text/plain`.
-
-```toml
-[tasks.with-plain-text.body]
-plain = "seinding body"
-```
-
-### tasks.{NAME}.body.json = {OBJECT}
-
-Specify request json body with `Content-Type: application/json`.
-
-```toml
-[tasks.with-json.body.json]
-number = 42
-string = "foo"
-nested.value = "bar"
-```
-
-### tasks.{NAME}.body.form = {TABLE}
-
-Specify request form body with `Content-Type: application/x-www-form-urlencoded`.
-
-```toml
-[tasks.with-form.body.form]
-key = "value"
-```
-
-### tasks.{NAME}.body.multipart = {TABLE}
-
-Specify request multipart body with `Content-Type: multipart/form-data`.
-To upload files, file path tagged with `file`.
-
-```toml
-[tasks.post.body.multipart]
-file-to-upload.file = "/path/to/upload/file"
-text = "plain text"
-```
-
-### tasks.{NAME}.config
-
-Specify configure for each task.
-This setting overwrites top-level configure.
-See [config](#config) for details.
-
-### variables = {TABLE}
-
-Define variables for string interpolation. For example:
+Use variables to manage API tokens:
 
 ```toml
 [variables]
-DOMAIN = "example.com"
-TOKEN = "XXXX-XXXX"
-KEY = "interpolated-key"
+TOKEN = "your-api-token-here"
 
-[tasks.interp]
-GET = "https://${DOMAIN}"
-# => resolved by `GET = "https://example.com"`
+[tasks.authenticated]
+GET = 'https://api.example.com/protected'
 
-[tasks.interp.headers]
+[tasks.authenticated.headers]
 Authorization = "Bearer ${TOKEN}"
-# => resolved by `AUthorization = "Bearer XXXX-XXXX"`
-
-[tasks.interp.queries]
-"${KEY}" = "value"
-# => resolved by `"interpolated-key" = "value"`
 ```
 
-### config
+Override variables from command line:
 
-### config.insecure = {BOOLEAN}
+```shell
+$ req authenticated -v TOKEN=different-token
+```
 
-If `true`, ignore verifying the SSL certificate. (default: `false`)
+### 3. Managing Multiple Environments
 
-### config.redirect = {INTEGER >= 0}
+Create separate config files for each environment:
 
-Specify a maximum number of redirects. (default: `0`)
+```toml
+# req.dev.toml
+[variables]
+BASE_URL = "https://dev.api.example.com"
+
+[tasks.test]
+GET = "${BASE_URL}/endpoint"
+```
+
+```toml
+# req.prod.toml
+[variables]
+BASE_URL = "https://api.example.com"
+
+[tasks.test]
+GET = "${BASE_URL}/endpoint"
+```
+
+Switch between environments:
+
+```shell
+$ req test -f req.dev.toml
+$ req test -f req.prod.toml
+```
+
+### 4. Sending Different Types of Request Bodies
+
+**Plain Text:**
+
+```toml
+[tasks.plain]
+POST = 'https://httpbin.org/post'
+
+[tasks.plain.body]
+plain = "Hello, World!"
+```
+
+**JSON:**
+
+```toml
+[tasks.json]
+POST = 'https://httpbin.org/post'
+
+[tasks.json.body.json]
+name = "Alice"
+age = 30
+active = true
+```
+
+**Form Data:**
+
+```toml
+[tasks.form]
+POST = 'https://httpbin.org/post'
+
+[tasks.form.body.form]
+username = "alice"
+password = "secret"
+```
+
+**Multipart (File Upload):**
+
+```toml
+[tasks.upload]
+POST = 'https://httpbin.org/post'
+
+[tasks.upload.body.multipart]
+document.file = "/path/to/document.pdf"
+description = "My document"
+```
+
+### 5. Working with Query Parameters and Headers
+
+```toml
+[tasks.search]
+GET = 'https://api.example.com/search'
+
+[tasks.search.queries]
+q = "rust programming"
+limit = "10"
+sort = "relevance"
+
+[tasks.search.headers]
+Accept = "application/json"
+User-Agent = "req/1.0"
+```
+
+### 6. Testing Requests Before Sending
+
+Use `--dryrun` to see what will be sent:
+
+```shell
+$ req create-user --dryrun
+```
+
+Generate equivalent curl command:
+
+```shell
+$ req create-user --curl
+curl -X POST 'https://api.example.com/users' \
+  -H 'Content-Type: application/json' \
+  -d '{"name":"John Doe","email":"john@example.com"}'
+```
+
+### 7. Debugging Responses
+
+Include response headers in output:
+
+```shell
+$ req get-user -i
+```
+
+### 8. Working with Self-Signed Certificates
+
+For development/testing environments:
+
+```toml
+[config]
+insecure = true
+
+[tasks.dev-api]
+GET = 'https://dev.local/api'
+```
+
+### 9. Following Redirects
+
+```toml
+[config]
+redirect = 5  # Follow up to 5 redirects
+
+[tasks.shortened]
+GET = 'https://short.url/abc123'
+```
+
+### 10. Task-Specific Configuration
+
+Override global config per task:
+
+```toml
+[config]
+redirect = 0
+insecure = false
+
+[tasks.special]
+GET = 'https://example.com/redirect'
+
+[tasks.special.config]
+redirect = 10
+insecure = true
+```
+
+## Next Steps
+
+- See [REFERENCE.md](REFERENCE.md) for complete configuration reference
+- Check out example configurations in the `examples/` directory
+- Run `req --help` for all available options
+
+## Tips
+
+- Store sensitive tokens in environment variables and pass them with `-v`
+- Use descriptive task names to make your workflow self-documenting
+- Share `req.toml` files with your team for consistent API testing
+- Combine with shell scripts for automated testing workflows

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -94,7 +94,7 @@ Define a task named `{NAME}`.
 
 ### tasks.{NAME}.description
 
-Speify description for the task.
+Specify description for the task.
 
 ### tasks.{NAME}.GET = {URL}
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -55,7 +55,7 @@ Include response headers in the output
 ### -v, --var
 
 Pass variable in the form `KEY=VALUE`.
-This option can be specified multple times.
+This option can be specified multiple times.
 
 ### --dryrun
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -1,0 +1,203 @@
+# req
+
+**req** is a command-line tool for sending http request.
+
+## Basic Usage
+
+Request tasks are defined in a file usually named `req.toml`. For example:
+
+```toml
+[tasks.get]
+GET = 'https://httpbin.org/get'
+description = "GET request"
+
+[tasks.post]
+POST = 'https://httpbin.org/post'
+description = "POST request"
+```
+
+To send request, run `req` command with task name:
+
+```shell
+$ req get
+# => GET https://httpbin.org/get
+
+$ req post
+# => POST https://httpbin.org/post
+```
+
+Without task name, `req` prints list of tasks:
+
+```shell
+$ req
+get     GET request
+post    POST request
+```
+
+## CLI Options
+
+### -h, --help
+
+Print help information.
+
+### -V, --version
+
+Print version information.
+
+### -f, --file `<DEF>`
+
+Read task definitions from `<DEF>`. (default: `req.toml`)
+
+### -i, --include-header
+
+Include response headers in the output
+
+### -v, --var
+
+Pass variable in the form `KEY=VALUE`.
+This option can be specified multple times.
+
+### --dryrun
+
+Dump internal structure of specified task without sending request.
+
+```shell
+$ req get --dryrun
+ReqTask {
+    method: Get(
+        "https://httpbin.org/get",
+    ),
+    headers: {},
+    queries: {},
+    body: Plain(
+        "",
+    ),
+    description: "GET request",
+    config: None,
+}
+```
+
+### [experimental] --curl
+
+Print compatible curl command. _This feature may not perform stably._
+
+```
+$ req get --curl
+curl -X GET 'https://httpbin.org/get'
+```
+
+## Configuration
+
+### tasks.{NAME}
+
+Define a task named `{NAME}`.
+
+### tasks.{NAME}.description
+
+Speify description for the task.
+
+### tasks.{NAME}.GET = {URL}
+
+### tasks.{NAME}.POST = {URL}
+
+### tasks.{NAME}.PUT = {URL}
+
+### tasks.{NAME}.DELETE = {URL}
+
+### tasks.{NAME}.HEAD = {URL}
+
+### tasks.{NAME}.OPTIONS = {URL}
+
+### tasks.{NAME}.CONNECT = {URL}
+
+### tasks.{NAME}.PATCH = {URL}
+
+### tasks.{NAME}.TRACE = {URL}
+
+Specify HTTP method and URL to send request.
+
+### tasks.{NAME}.headers = {TABLE}
+
+### tasks.{NAME}.queries = {TABLE}
+
+Specify headers and queries as table to be given to request.
+Values of these table should be string or array of string.
+
+### tasks.{NAME}.body.plain = {TEXT}
+
+Specify request plain text body with `Content-Type: text/plain`.
+
+```toml
+[tasks.with-plain-text.body]
+plain = "seinding body"
+```
+
+### tasks.{NAME}.body.json = {OBJECT}
+
+Specify request json body with `Content-Type: application/json`.
+
+```toml
+[tasks.with-json.body.json]
+number = 42
+string = "foo"
+nested.value = "bar"
+```
+
+### tasks.{NAME}.body.form = {TABLE}
+
+Specify request form body with `Content-Type: application/x-www-form-urlencoded`.
+
+```toml
+[tasks.with-form.body.form]
+key = "value"
+```
+
+### tasks.{NAME}.body.multipart = {TABLE}
+
+Specify request multipart body with `Content-Type: multipart/form-data`.
+To upload files, file path tagged with `file`.
+
+```toml
+[tasks.post.body.multipart]
+file-to-upload.file = "/path/to/upload/file"
+text = "plain text"
+```
+
+### tasks.{NAME}.config
+
+Specify configure for each task.
+This setting overwrites top-level configure.
+See [config](#config) for details.
+
+### variables = {TABLE}
+
+Define variables for string interpolation. For example:
+
+```toml
+[variables]
+DOMAIN = "example.com"
+TOKEN = "XXXX-XXXX"
+KEY = "interpolated-key"
+
+[tasks.interp]
+GET = "https://${DOMAIN}"
+# => resolved by `GET = "https://example.com"`
+
+[tasks.interp.headers]
+Authorization = "Bearer ${TOKEN}"
+# => resolved by `AUthorization = "Bearer XXXX-XXXX"`
+
+[tasks.interp.queries]
+"${KEY}" = "value"
+# => resolved by `"interpolated-key" = "value"`
+```
+
+### config
+
+### config.insecure = {BOOLEAN}
+
+If `true`, ignore verifying the SSL certificate. (default: `false`)
+
+### config.redirect = {INTEGER >= 0}
+
+Specify a maximum number of redirects. (default: `0`)

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -185,7 +185,7 @@ GET = "https://${DOMAIN}"
 
 [tasks.interp.headers]
 Authorization = "Bearer ${TOKEN}"
-# => resolved by `AUthorization = "Bearer XXXX-XXXX"`
+# => resolved by `Authorization = "Bearer XXXX-XXXX"`
 
 [tasks.interp.queries]
 "${KEY}" = "value"

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -129,7 +129,7 @@ Specify request plain text body with `Content-Type: text/plain`.
 
 ```toml
 [tasks.with-plain-text.body]
-plain = "seinding body"
+plain = "sending body"
 ```
 
 ### tasks.{NAME}.body.json = {OBJECT}


### PR DESCRIPTION
- Move original README content to REFERENCE.md for complete reference
- Rewrite README with practical use cases and examples
- Add "Why req?" section to clarify the tool's purpose
- Organize content by common workflows instead of configuration options
- Include 10 practical use cases from basic to advanced scenarios

This makes the documentation more accessible to new users while preserving all technical details in REFERENCE.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)