### PR TITLE
feat: add proxy server configuration support

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -250,3 +250,113 @@ env-file = true  # Loads .env
 # Or specify custom file
 env-file = ".env.development"
 ```
+
+### config.proxy = {STRING | OBJECT}
+
+Specify proxy server for both HTTP and HTTPS requests.
+
+As a string:
+```toml
+[config]
+proxy = "http://proxy.example.com:8080"
+```
+
+As an object with authentication:
+```toml
+[config.proxy]
+url = "http://proxy.example.com:8080"
+username = "myuser"
+password = "mypass"
+```
+
+### config.proxy.http = {STRING | OBJECT}
+
+### config.proxy.https = {STRING | OBJECT}
+
+Specify proxy server for HTTP or HTTPS requests separately. Both can be specified at the same time.
+
+As strings:
+```toml
+# HTTP only
+[config.proxy]
+http = "http://http-proxy.example.com:8080"
+
+# HTTPS only
+[config.proxy]
+https = "http://https-proxy.example.com:8443"
+
+# Both HTTP and HTTPS with different proxies
+[config.proxy]
+http = "http://http-proxy.example.com:8080"
+https = "http://https-proxy.example.com:8443"
+```
+
+As objects with authentication:
+```toml
+# HTTP with authentication
+[config.proxy.http]
+url = "http://http-proxy.example.com:8080"
+username = "http-user"
+password = "http-pass"
+
+# HTTPS with authentication
+[config.proxy.https]
+url = "http://https-proxy.example.com:8443"
+username = "https-user"
+password = "https-pass"
+
+# Mixed: HTTP without auth, HTTPS with auth
+[config.proxy]
+http = "http://http-proxy.example.com:8080"
+
+[config.proxy.https]
+url = "http://https-proxy.example.com:8443"
+username = "https-user"
+password = "https-pass"
+```
+
+Variable interpolation is supported:
+
+```toml
+[variables]
+PROXY_URL = "http://proxy.example.com:8080"
+
+[config]
+proxy = "${PROXY_URL}"
+
+# With authentication
+[variables]
+PROXY_URL = "http://proxy.example.com:8080"
+PROXY_USER = "myuser"
+PROXY_PASS = "mypass"
+
+[config.proxy]
+url = "${PROXY_URL}"
+username = "${PROXY_USER}"
+password = "${PROXY_PASS}"
+
+# Or in detailed form
+[variables]
+HTTP_PROXY = "http://http-proxy.example.com:8080"
+HTTPS_PROXY = "http://https-proxy.example.com:8443"
+HTTP_USER = "http-user"
+HTTPS_USER = "https-user"
+
+[config.proxy]
+http = "${HTTP_PROXY}"
+
+[config.proxy.https]
+url = "${HTTPS_PROXY}"
+username = "${HTTPS_USER}"
+password = "secret"
+```
+
+Task-level proxy configuration overrides global configuration:
+
+```toml
+[config]
+proxy = "http://global-proxy.example.com:8080"
+
+[tasks.special-task.config]
+proxy = "http://task-specific-proxy.example.com:8080"
+```

--- a/src/data.rs
+++ b/src/data.rs
@@ -94,6 +94,120 @@ impl EnvFile {
     }
 }
 
+#[derive(Debug, Clone, Deserialize)]
+#[serde(untagged)]
+enum ReqProxyUrl {
+    Simple(String),
+    Detailed {
+        url: String,
+        #[serde(default)]
+        username: Option<String>,
+        #[serde(default)]
+        password: Option<String>,
+    },
+}
+
+impl ReqProxyUrl {
+    fn interpolate(&self, ctxt: &InterpContext) -> InterpResult<Self> {
+        Ok(match self {
+            ReqProxyUrl::Simple(url) => ReqProxyUrl::Simple(interpolate(url, ctxt)?),
+            ReqProxyUrl::Detailed {
+                url,
+                username,
+                password,
+            } => ReqProxyUrl::Detailed {
+                url: interpolate(url, ctxt)?,
+                username: username
+                    .as_ref()
+                    .map(|u| interpolate(u, ctxt))
+                    .transpose()?,
+                password: password
+                    .as_ref()
+                    .map(|p| interpolate(p, ctxt))
+                    .transpose()?,
+            },
+        })
+    }
+
+    fn url(&self) -> &str {
+        match self {
+            ReqProxyUrl::Simple(url) => url,
+            ReqProxyUrl::Detailed { url, .. } => url,
+        }
+    }
+
+    fn credentials(&self) -> Option<(&str, &str)> {
+        match self {
+            ReqProxyUrl::Simple(_) => None,
+            ReqProxyUrl::Detailed {
+                username: Some(u),
+                password: Some(p),
+                ..
+            } => Some((u, p)),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(untagged)]
+enum ReqProxy {
+    Simple(ReqProxyUrl),
+    Detailed {
+        #[serde(default)]
+        http: Option<ReqProxyUrl>,
+        #[serde(default)]
+        https: Option<ReqProxyUrl>,
+    },
+}
+
+impl ReqProxy {
+    fn interpolate(&self, ctxt: &InterpContext) -> InterpResult<Self> {
+        Ok(match self {
+            ReqProxy::Simple(proxy_url) => ReqProxy::Simple(proxy_url.interpolate(ctxt)?),
+            ReqProxy::Detailed { http, https } => ReqProxy::Detailed {
+                http: http
+                    .as_ref()
+                    .map(|p| p.interpolate(ctxt))
+                    .transpose()?,
+                https: https
+                    .as_ref()
+                    .map(|p| p.interpolate(ctxt))
+                    .transpose()?,
+            },
+        })
+    }
+
+    fn apply_to_client(&self, mut builder: ClientBuilder) -> anyhow::Result<ClientBuilder> {
+        match self {
+            ReqProxy::Simple(proxy_url) => {
+                let mut proxy = reqwest::Proxy::all(proxy_url.url())?;
+                if let Some((username, password)) = proxy_url.credentials() {
+                    proxy = proxy.basic_auth(username, password);
+                }
+                builder = builder.proxy(proxy);
+            }
+            ReqProxy::Detailed { http, https } => {
+                if let Some(proxy_url) = http {
+                    let mut proxy = reqwest::Proxy::http(proxy_url.url())?;
+                    if let Some((username, password)) = proxy_url.credentials() {
+                        proxy = proxy.basic_auth(username, password);
+                    }
+                    builder = builder.proxy(proxy);
+                }
+                if let Some(proxy_url) = https {
+                    let mut proxy = reqwest::Proxy::https(proxy_url.url())?;
+                    if let Some((username, password)) = proxy_url.credentials() {
+                        proxy = proxy.basic_auth(username, password);
+                    }
+                    builder = builder.proxy(proxy);
+                }
+            }
+        }
+        Ok(builder)
+    }
+}
+
 #[derive(Debug, Clone, Deserialize, Default)]
 struct ReqConfig {
     #[serde(default)]
@@ -102,6 +216,8 @@ struct ReqConfig {
     redirect: usize,
     #[serde(default, rename = "env-file")]
     env_file: EnvFile,
+    #[serde(default)]
+    proxy: Option<ReqProxy>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -268,13 +384,26 @@ impl ReqBody {
 }
 
 impl ReqConfig {
+    fn interpolate(&self, ctxt: &InterpContext) -> InterpResult<Self> {
+        Ok(ReqConfig {
+            insecure: self.insecure,
+            redirect: self.redirect,
+            env_file: self.env_file.clone(),
+            proxy: self
+                .proxy
+                .as_ref()
+                .map(|p| p.interpolate(ctxt))
+                .transpose()?,
+        })
+    }
+
     fn client(&self) -> anyhow::Result<Client> {
         let policy = if self.redirect > 0 {
             reqwest::redirect::Policy::limited(self.redirect)
         } else {
             reqwest::redirect::Policy::none()
         };
-        Ok(ClientBuilder::new()
+        let mut builder = ClientBuilder::new()
             .danger_accept_invalid_certs(self.insecure)
             .user_agent(format!(
                 "{}/{}",
@@ -282,8 +411,13 @@ impl ReqConfig {
                 env!("CARGO_PKG_VERSION")
             ))
             .redirect(policy)
-            .timeout(None)
-            .build()?)
+            .timeout(None);
+
+        if let Some(ref proxy) = self.proxy {
+            builder = proxy.apply_to_client(builder)?;
+        }
+
+        Ok(builder.build()?)
     }
 }
 
@@ -296,13 +430,17 @@ impl ReqTask {
             ref body,
             description,
             ref auth,
-            config,
+            ref config,
         } = self;
         let method = method.interpolatte(ctxt)?;
         let headers = interpolate_btree_map(headers, ctxt)?;
         let queries = interpolate_btree_map(queries, ctxt)?;
         let body = body.interpolate(ctxt)?;
         let auth = auth.as_ref().map(|a| a.interpolate(ctxt)).transpose()?;
+        let config = config
+            .as_ref()
+            .map(|c| c.interpolate(ctxt))
+            .transpose()?;
 
         Ok(ReqTask {
             method,
@@ -311,7 +449,7 @@ impl ReqTask {
             body,
             description: description.clone(),
             auth,
-            config: config.clone(),
+            config,
         })
     }
 
@@ -531,7 +669,7 @@ mod tests {
 
         let input = json!({
             "number": 42,
-            "float": 3.14,
+            "float": 0.1,
             "bool": true,
             "null": null,
             "array": [1, 2, 3]
@@ -559,5 +697,192 @@ mod tests {
             "active": true,
             "items": ["hello", 123, false]
         }));
+    }
+
+    #[test]
+    fn test_proxy_url_simple() {
+        use serde::Deserialize;
+
+        #[derive(Deserialize)]
+        struct TestConfig {
+            proxy: ReqProxyUrl,
+        }
+
+        let toml_str = r#"proxy = "http://proxy.example.com:8080""#;
+        let config: TestConfig = toml::from_str(toml_str).unwrap();
+        let proxy_url = config.proxy;
+
+        match &proxy_url {
+            ReqProxyUrl::Simple(url) => {
+                assert_eq!(url, "http://proxy.example.com:8080");
+            }
+            _ => panic!("Expected Simple variant"),
+        }
+
+        assert_eq!(proxy_url.url(), "http://proxy.example.com:8080");
+        assert_eq!(proxy_url.credentials(), None);
+    }
+
+    #[test]
+    fn test_proxy_url_detailed_with_auth() {
+        let toml_str = r#"
+            url = "http://proxy.example.com:8080"
+            username = "user"
+            password = "pass"
+        "#;
+        let proxy_url: ReqProxyUrl = toml::from_str(toml_str).unwrap();
+
+        match &proxy_url {
+            ReqProxyUrl::Detailed { url, username, password } => {
+                assert_eq!(url, "http://proxy.example.com:8080");
+                assert_eq!(username.as_deref(), Some("user"));
+                assert_eq!(password.as_deref(), Some("pass"));
+            }
+            _ => panic!("Expected Detailed variant"),
+        }
+
+        assert_eq!(proxy_url.url(), "http://proxy.example.com:8080");
+        assert_eq!(proxy_url.credentials(), Some(("user", "pass")));
+    }
+
+    #[test]
+    fn test_proxy_url_interpolate() {
+        let mut vars = BTreeMap::new();
+        vars.insert("PROXY_URL".to_string(), "http://proxy.example.com:8080".to_string());
+        vars.insert("PROXY_USER".to_string(), "myuser".to_string());
+        vars.insert("PROXY_PASS".to_string(), "mypass".to_string());
+        let ctxt = create_interpolation_context(vars).unwrap();
+
+        let toml_str = r#"
+            url = "${PROXY_URL}"
+            username = "${PROXY_USER}"
+            password = "${PROXY_PASS}"
+        "#;
+        let proxy_url: ReqProxyUrl = toml::from_str(toml_str).unwrap();
+        let interpolated = proxy_url.interpolate(&ctxt).unwrap();
+
+        assert_eq!(interpolated.url(), "http://proxy.example.com:8080");
+        assert_eq!(interpolated.credentials(), Some(("myuser", "mypass")));
+    }
+
+    #[test]
+    fn test_proxy_simple() {
+        use serde::Deserialize;
+
+        #[derive(Deserialize)]
+        struct TestConfig {
+            proxy: ReqProxy,
+        }
+
+        let toml_str = r#"proxy = "http://proxy.example.com:8080""#;
+        let config: TestConfig = toml::from_str(toml_str).unwrap();
+
+        match &config.proxy {
+            ReqProxy::Simple(_) => {},
+            _ => panic!("Expected Simple variant"),
+        }
+    }
+
+    #[test]
+    fn test_proxy_detailed() {
+        let toml_str = r#"
+            http = "http://http-proxy.example.com:8080"
+            https = "http://https-proxy.example.com:8443"
+        "#;
+        let proxy: ReqProxy = toml::from_str(toml_str).unwrap();
+
+        match &proxy {
+            ReqProxy::Detailed { http, https } => {
+                assert!(http.is_some());
+                assert!(https.is_some());
+                assert_eq!(http.as_ref().unwrap().url(), "http://http-proxy.example.com:8080");
+                assert_eq!(https.as_ref().unwrap().url(), "http://https-proxy.example.com:8443");
+            }
+            _ => panic!("Expected Detailed variant"),
+        }
+    }
+
+    #[test]
+    fn test_proxy_detailed_with_auth() {
+        let toml_str = r#"
+            [http]
+            url = "http://http-proxy.example.com:8080"
+            username = "http-user"
+            password = "http-pass"
+
+            [https]
+            url = "http://https-proxy.example.com:8443"
+            username = "https-user"
+            password = "https-pass"
+        "#;
+        let proxy: ReqProxy = toml::from_str(toml_str).unwrap();
+
+        match &proxy {
+            ReqProxy::Detailed { http, https } => {
+                assert!(http.is_some());
+                assert!(https.is_some());
+
+                let http_proxy = http.as_ref().unwrap();
+                assert_eq!(http_proxy.url(), "http://http-proxy.example.com:8080");
+                assert_eq!(http_proxy.credentials(), Some(("http-user", "http-pass")));
+
+                let https_proxy = https.as_ref().unwrap();
+                assert_eq!(https_proxy.url(), "http://https-proxy.example.com:8443");
+                assert_eq!(https_proxy.credentials(), Some(("https-user", "https-pass")));
+            }
+            _ => panic!("Expected Detailed variant"),
+        }
+    }
+
+    #[test]
+    fn test_proxy_interpolate() {
+        let mut vars = BTreeMap::new();
+        vars.insert("HTTP_PROXY".to_string(), "http://http-proxy.example.com:8080".to_string());
+        vars.insert("HTTPS_PROXY".to_string(), "http://https-proxy.example.com:8443".to_string());
+        let ctxt = create_interpolation_context(vars).unwrap();
+
+        let toml_str = r#"
+            http = "${HTTP_PROXY}"
+            https = "${HTTPS_PROXY}"
+        "#;
+        let proxy: ReqProxy = toml::from_str(toml_str).unwrap();
+        let interpolated = proxy.interpolate(&ctxt).unwrap();
+
+        match interpolated {
+            ReqProxy::Detailed { http, https } => {
+                assert_eq!(http.as_ref().unwrap().url(), "http://http-proxy.example.com:8080");
+                assert_eq!(https.as_ref().unwrap().url(), "http://https-proxy.example.com:8443");
+            }
+            _ => panic!("Expected Detailed variant"),
+        }
+    }
+
+    #[test]
+    fn test_config_with_proxy() {
+        let toml_str = r#"
+            insecure = true
+            redirect = 5
+            proxy = "http://proxy.example.com:8080"
+        "#;
+        let config: ReqConfig = toml::from_str(toml_str).unwrap();
+
+        assert!(config.insecure);
+        assert_eq!(config.redirect, 5);
+        assert!(config.proxy.is_some());
+    }
+
+    #[test]
+    fn test_config_proxy_interpolate() {
+        let mut vars = BTreeMap::new();
+        vars.insert("PROXY_URL".to_string(), "http://proxy.example.com:8080".to_string());
+        let ctxt = create_interpolation_context(vars).unwrap();
+
+        let toml_str = r#"
+            proxy = "${PROXY_URL}"
+        "#;
+        let config: ReqConfig = toml::from_str(toml_str).unwrap();
+        let interpolated = config.interpolate(&ctxt).unwrap();
+
+        assert!(interpolated.proxy.is_some());
     }
 }

--- a/src/data.rs
+++ b/src/data.rs
@@ -692,8 +692,6 @@ mod tests {
 
     #[test]
     fn test_proxy_url_simple() {
-        use serde::Deserialize;
-
         #[derive(Deserialize)]
         struct TestConfig {
             proxy: ReqProxyUrl,
@@ -758,8 +756,6 @@ mod tests {
 
     #[test]
     fn test_proxy_simple() {
-        use serde::Deserialize;
-
         #[derive(Deserialize)]
         struct TestConfig {
             proxy: ReqProxy,

--- a/src/data.rs
+++ b/src/data.rs
@@ -100,10 +100,8 @@ enum ReqProxyUrl {
     Simple(String),
     Detailed {
         url: String,
-        #[serde(default)]
-        username: Option<String>,
-        #[serde(default)]
-        password: Option<String>,
+        username: String,
+        password: String,
     },
 }
 
@@ -117,14 +115,8 @@ impl ReqProxyUrl {
                 password,
             } => ReqProxyUrl::Detailed {
                 url: interpolate(url, ctxt)?,
-                username: username
-                    .as_ref()
-                    .map(|u| interpolate(u, ctxt))
-                    .transpose()?,
-                password: password
-                    .as_ref()
-                    .map(|p| interpolate(p, ctxt))
-                    .transpose()?,
+                username: interpolate(username, ctxt)?,
+                password: interpolate(password, ctxt)?,
             },
         })
     }
@@ -140,11 +132,10 @@ impl ReqProxyUrl {
         match self {
             ReqProxyUrl::Simple(_) => None,
             ReqProxyUrl::Detailed {
-                username: Some(u),
-                password: Some(p),
+                username,
+                password,
                 ..
-            } => Some((u, p)),
-            _ => None,
+            } => Some((username, password)),
         }
     }
 }
@@ -735,8 +726,8 @@ mod tests {
         match &proxy_url {
             ReqProxyUrl::Detailed { url, username, password } => {
                 assert_eq!(url, "http://proxy.example.com:8080");
-                assert_eq!(username.as_deref(), Some("user"));
-                assert_eq!(password.as_deref(), Some("pass"));
+                assert_eq!(username, "user");
+                assert_eq!(password, "pass");
             }
             _ => panic!("Expected Detailed variant"),
         }


### PR DESCRIPTION
## Summary

Adds comprehensive proxy server configuration support to req-rs with authentication and variable interpolation.

## Features

- **Simple form**: `config.proxy = "url"` for applying proxy to all protocols (HTTP/HTTPS)
- **Detailed form**: `config.proxy.http/https` for protocol-specific proxy configuration
- **Authentication support**: Username and password fields for proxy authentication
- **Variable interpolation**: Full support for variable substitution in all proxy settings
- **Independent credentials**: Different authentication for HTTP and HTTPS proxies

## Implementation

- Add `ReqProxyUrl` enum for handling simple string or detailed config with auth
- Add `ReqProxy` enum supporting both simple and detailed proxy configurations
- Extend `ReqConfig` with optional proxy field
- Implement proxy interpolation in `ReqConfig::interpolate()`
- Apply proxy settings in `ReqConfig::client()` via `apply_to_client()`
- Support Basic authentication for proxies using reqwest's `basic_auth()`

## Configuration Examples

### Simple form (all protocols)
```toml
[config]
proxy = "http://proxy.example.com:8080"
```

### With authentication
```toml
[config.proxy]
url = "http://proxy.example.com:8080"
username = "user"
password = "pass"
```

### Protocol-specific with different credentials
```toml
[config.proxy.http]
url = "http://http-proxy.example.com:8080"
username = "http-user"
password = "http-pass"

[config.proxy.https]
url = "http://https-proxy.example.com:8443"
username = "https-user"
password = "https-pass"
```

## Testing

- Added 9 comprehensive unit tests
- All 49 tests passing
- Linter clean
- Build successful

## Documentation

- Updated REFERENCE.md with complete proxy configuration documentation
- Includes multiple usage examples and variable interpolation patterns

🤖 Generated with [Claude Code](https://claude.com/claude-code)