### PR TITLE
test: add snapshot tests for --curl option

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -240,6 +240,18 @@ dependencies = [
 
 [[package]]
 name = "console"
+version = "0.15.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "console"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b430743a6eb14e9764d4260d4c0d8123087d504eeb9c48f2b2a5e810dd369df4"
@@ -831,11 +843,22 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70a646d946d06bedbbc4cac4c218acf4bbf2d87757a784857025f4d447e4e1cd"
 dependencies = [
- "console",
+ "console 0.16.1",
  "portable-atomic",
  "unicode-width",
  "unit-prefix",
  "web-time",
+]
+
+[[package]]
+name = "insta"
+version = "1.43.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46fdb647ebde000f43b5b53f773c30cf9b0cb4300453208713fa38b2c70935a0"
+dependencies = [
+ "console 0.15.11",
+ "once_cell",
+ "similar",
 ]
 
 [[package]]
@@ -1141,6 +1164,7 @@ dependencies = [
  "dotenvy",
  "httpmock",
  "indicatif",
+ "insta",
  "regex",
  "reqwest",
  "rstest",
@@ -1262,7 +1286,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1538,7 +1562,7 @@ dependencies = [
  "getrandom 0.3.1",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,3 +33,4 @@ httpmock = "0.8.2"
 rstest = "0.26.1"
 tempfile = "3.23.0"
 uuid = { version = "1.16.0", features = ["v4"] }
+insta = "1.41"

--- a/src/main.rs
+++ b/src/main.rs
@@ -176,7 +176,7 @@ impl Opt {
         }
 
         if self.curl {
-            println!("{}", task.to_curl()?);
+            writeln!(w, "{}", task.to_curl()?)?;
             return Ok(ExitCode::SUCCESS);
         }
 
@@ -864,7 +864,7 @@ mod tests {
                 [tasks.test]
                 POST = "https://example.com/api/users"
 
-                [tasks.test.data]
+                [tasks.test.body.json]
                 name = "John Doe"
                 email = "john@example.com"
             "#,
@@ -910,7 +910,7 @@ mod tests {
                 [tasks.test]
                 POST = "https://example.com/api/data"
 
-                [tasks.test.data]
+                [tasks.test.body.json]
                 description = "Line 1\nLine 2\nLine 3"
                 title = "Test"
             "#,

--- a/src/main.rs
+++ b/src/main.rs
@@ -845,4 +845,99 @@ mod tests {
         mock.assert();
         assert_eq!(code, ExitCode::SUCCESS);
     }
+
+    mod curl_option_tests {
+        use super::*;
+        use std::io::Cursor;
+
+        #[rstest]
+        #[case::basic_get(
+            r#"
+                [tasks.test]
+                GET = "https://example.com/api/users"
+            "#,
+            vec!["req", "-f", "-", "--curl", "test"],
+            "basic_get"
+        )]
+        #[case::post_with_json_body(
+            r#"
+                [tasks.test]
+                POST = "https://example.com/api/users"
+
+                [tasks.test.data]
+                name = "John Doe"
+                email = "john@example.com"
+            "#,
+            vec!["req", "-f", "-", "--curl", "test"],
+            "post_with_json_body"
+        )]
+        #[case::with_custom_headers(
+            r#"
+                [tasks.test]
+                GET = "https://example.com/api/users"
+
+                [tasks.test.headers]
+                Authorization = "Bearer token123"
+                X-Custom-Header = "custom-value"
+            "#,
+            vec!["req", "-f", "-", "--curl", "test"],
+            "with_custom_headers"
+        )]
+        #[case::with_insecure_option(
+            r#"
+                [tasks.test]
+                GET = "https://self-signed.example.com/api"
+
+                [tasks.test.config]
+                insecure = true
+            "#,
+            vec!["req", "-f", "-", "--curl", "test"],
+            "with_insecure_option"
+        )]
+        #[case::with_redirect_option(
+            r#"
+                [tasks.test]
+                GET = "https://example.com/redirect"
+
+                [tasks.test.config]
+                redirect = 5
+            "#,
+            vec!["req", "-f", "-", "--curl", "test"],
+            "with_redirect_option"
+        )]
+        #[case::post_with_multiline_body(
+            r#"
+                [tasks.test]
+                POST = "https://example.com/api/data"
+
+                [tasks.test.data]
+                description = "Line 1\nLine 2\nLine 3"
+                title = "Test"
+            "#,
+            vec!["req", "-f", "-", "--curl", "test"],
+            "post_with_multiline_body"
+        )]
+        #[case::with_special_chars_in_url(
+            r#"
+                [tasks.test]
+                GET = "https://example.com/api/search?q=test&lang=en"
+            "#,
+            vec!["req", "-f", "-", "--curl", "test"],
+            "with_special_chars_in_url"
+        )]
+        fn test_curl_output(
+            #[case] input: &str,
+            #[case] args: Vec<&str>,
+            #[case] snapshot_name: &str,
+        ) {
+            let opt = Opt::try_parse_from(args).unwrap();
+            let mut output = Cursor::new(Vec::new());
+
+            let code = opt.exec(&mut input.as_bytes(), &mut output).unwrap();
+
+            assert_eq!(code, ExitCode::SUCCESS);
+            let output_str = String::from_utf8(output.into_inner()).unwrap();
+            insta::assert_snapshot!(snapshot_name, output_str);
+        }
+    }
 }

--- a/src/snapshots/req__tests__curl_option_tests__basic_get.snap
+++ b/src/snapshots/req__tests__curl_option_tests__basic_get.snap
@@ -2,4 +2,4 @@
 source: src/main.rs
 expression: output_str
 ---
-
+curl -X GET 'https://example.com/api/users'

--- a/src/snapshots/req__tests__curl_option_tests__basic_get.snap
+++ b/src/snapshots/req__tests__curl_option_tests__basic_get.snap
@@ -1,0 +1,5 @@
+---
+source: src/main.rs
+expression: output_str
+---
+

--- a/src/snapshots/req__tests__curl_option_tests__post_with_json_body.snap
+++ b/src/snapshots/req__tests__curl_option_tests__post_with_json_body.snap
@@ -2,4 +2,8 @@
 source: src/main.rs
 expression: output_str
 ---
-
+curl -X POST 'https://example.com/api/users' \
+	-H 'content-type:application/json' \
+	-d @- << REQUEST_BODY
+{"email":"john@example.com","name":"John Doe"}
+REQUEST_BODY

--- a/src/snapshots/req__tests__curl_option_tests__post_with_json_body.snap
+++ b/src/snapshots/req__tests__curl_option_tests__post_with_json_body.snap
@@ -1,0 +1,5 @@
+---
+source: src/main.rs
+expression: output_str
+---
+

--- a/src/snapshots/req__tests__curl_option_tests__post_with_multiline_body.snap
+++ b/src/snapshots/req__tests__curl_option_tests__post_with_multiline_body.snap
@@ -2,4 +2,8 @@
 source: src/main.rs
 expression: output_str
 ---
-
+curl -X POST 'https://example.com/api/data' \
+	-H 'content-type:application/json' \
+	-d @- << REQUEST_BODY
+{"description":"Line 1\nLine 2\nLine 3","title":"Test"}
+REQUEST_BODY

--- a/src/snapshots/req__tests__curl_option_tests__post_with_multiline_body.snap
+++ b/src/snapshots/req__tests__curl_option_tests__post_with_multiline_body.snap
@@ -1,0 +1,5 @@
+---
+source: src/main.rs
+expression: output_str
+---
+

--- a/src/snapshots/req__tests__curl_option_tests__with_custom_headers.snap
+++ b/src/snapshots/req__tests__curl_option_tests__with_custom_headers.snap
@@ -2,4 +2,6 @@
 source: src/main.rs
 expression: output_str
 ---
-
+curl -X GET 'https://example.com/api/users' \
+	-H 'authorization:Bearer token123' \
+	-H 'x-custom-header:custom-value'

--- a/src/snapshots/req__tests__curl_option_tests__with_custom_headers.snap
+++ b/src/snapshots/req__tests__curl_option_tests__with_custom_headers.snap
@@ -1,0 +1,5 @@
+---
+source: src/main.rs
+expression: output_str
+---
+

--- a/src/snapshots/req__tests__curl_option_tests__with_insecure_option.snap
+++ b/src/snapshots/req__tests__curl_option_tests__with_insecure_option.snap
@@ -2,4 +2,4 @@
 source: src/main.rs
 expression: output_str
 ---
-
+curl -k -X GET 'https://self-signed.example.com/api'

--- a/src/snapshots/req__tests__curl_option_tests__with_insecure_option.snap
+++ b/src/snapshots/req__tests__curl_option_tests__with_insecure_option.snap
@@ -1,0 +1,5 @@
+---
+source: src/main.rs
+expression: output_str
+---
+

--- a/src/snapshots/req__tests__curl_option_tests__with_redirect_option.snap
+++ b/src/snapshots/req__tests__curl_option_tests__with_redirect_option.snap
@@ -1,0 +1,5 @@
+---
+source: src/main.rs
+expression: output_str
+---
+

--- a/src/snapshots/req__tests__curl_option_tests__with_redirect_option.snap
+++ b/src/snapshots/req__tests__curl_option_tests__with_redirect_option.snap
@@ -2,4 +2,4 @@
 source: src/main.rs
 expression: output_str
 ---
-
+curl -L -X GET 'https://example.com/redirect'

--- a/src/snapshots/req__tests__curl_option_tests__with_special_chars_in_url.snap
+++ b/src/snapshots/req__tests__curl_option_tests__with_special_chars_in_url.snap
@@ -2,4 +2,4 @@
 source: src/main.rs
 expression: output_str
 ---
-
+curl -X GET 'https://example.com/api/search?q=test&lang=en'

--- a/src/snapshots/req__tests__curl_option_tests__with_special_chars_in_url.snap
+++ b/src/snapshots/req__tests__curl_option_tests__with_special_chars_in_url.snap
@@ -1,0 +1,5 @@
+---
+source: src/main.rs
+expression: output_str
+---
+


### PR DESCRIPTION
## Summary
- Add comprehensive snapshot tests for the `--curl` option using the `insta` crate
- Fix `--curl` implementation to write to the provided output stream instead of stdout

## Changes
1. Added `insta = "1.41"` to `dev-dependencies` in Cargo.toml
2. Created 7 snapshot test cases covering:
   - Basic GET requests
   - POST requests with JSON body
   - Custom headers
   - Insecure option (-k flag)
   - Redirect option (-L flag)
   - Multiline request bodies
   - Special characters in URLs
3. Fixed `--curl` implementation to use `writeln!(w, ...)` instead of `println!` to enable proper testing

## Test Results
All 56 tests pass (including 7 new curl option tests)

## Notes
- Snapshot files track curl command output to detect any unintended changes to the `--curl` feature
- The fix ensures that curl output is written to the provided writer, making it testable and consistent with other output operations

🤖 Generated with [Claude Code](https://claude.com/claude-code)