### PR TITLE
feat: add proxy and authentication support to --curl output 

### DIFF
--- a/src/data.rs
+++ b/src/data.rs
@@ -519,7 +519,9 @@ impl ReqTask {
                 ReqProxy::Simple(proxy_url) => {
                     lines.push(format!(" \\\n\t-x '{}'", proxy_url.url()));
                     if let Some((username, password)) = proxy_url.credentials() {
-                        lines.push(format!(" \\\n\t--proxy-user '{}:{}'", username, password));
+                        let escaped_user = username.replace("\\", "\\\\").replace("'", "\\'");
+                        let escaped_pass = password.replace("\\", "\\\\").replace("'", "\\'");
+                        lines.push(format!(" \\\n\t--proxy-user '{}:{}'", escaped_user, escaped_pass));
                     }
                 }
                 ReqProxy::Detailed { http, https } => {
@@ -534,7 +536,9 @@ impl ReqTask {
                     if let Some(proxy_url) = proxy_url {
                         lines.push(format!(" \\\n\t-x '{}'", proxy_url.url()));
                         if let Some((username, password)) = proxy_url.credentials() {
-                            lines.push(format!(" \\\n\t--proxy-user '{}:{}'", username, password));
+                            let escaped_user = username.replace("\\", "\\\\").replace("'", "\\'");
+                            let escaped_pass = password.replace("\\", "\\\\").replace("'", "\\'");
+                            lines.push(format!(" \\\n\t--proxy-user '{}:{}'", escaped_user, escaped_pass));
                         }
                     }
                 }

--- a/src/data.rs
+++ b/src/data.rs
@@ -512,6 +512,35 @@ impl ReqTask {
                 .replace("\'", "\\'"),
             request.url().as_str(),
         ));
+
+        // Add proxy settings
+        if let Some(ref proxy) = config.proxy {
+            match proxy {
+                ReqProxy::Simple(proxy_url) => {
+                    lines.push(format!(" \\\n\t-x '{}'", proxy_url.url()));
+                    if let Some((username, password)) = proxy_url.credentials() {
+                        lines.push(format!(" \\\n\t--proxy-user '{}:{}'", username, password));
+                    }
+                }
+                ReqProxy::Detailed { http, https } => {
+                    // For detailed proxy, prefer HTTPS proxy if the request URL is HTTPS
+                    let url_str = request.url().as_str();
+                    let proxy_url = if url_str.starts_with("https://") {
+                        https.as_ref().or(http.as_ref())
+                    } else {
+                        http.as_ref().or(https.as_ref())
+                    };
+
+                    if let Some(proxy_url) = proxy_url {
+                        lines.push(format!(" \\\n\t-x '{}'", proxy_url.url()));
+                        if let Some((username, password)) = proxy_url.credentials() {
+                            lines.push(format!(" \\\n\t--proxy-user '{}:{}'", username, password));
+                        }
+                    }
+                }
+            }
+        }
+
         for (k, v) in request.headers().iter() {
             let kv = format!("{}:{}", k, v.to_str().expect("invalid header string"))
                 .replace("\\", "\\\\")

--- a/src/main.rs
+++ b/src/main.rs
@@ -925,6 +925,65 @@ mod tests {
             vec!["req", "-f", "-", "--curl", "test"],
             "with_special_chars_in_url"
         )]
+        #[case::with_bearer_auth(
+            r#"
+                [tasks.test]
+                GET = "https://example.com/api/protected"
+
+                [tasks.test.auth]
+                bearer = "my-secret-token-123"
+            "#,
+            vec!["req", "-f", "-", "--curl", "test"],
+            "with_bearer_auth"
+        )]
+        #[case::with_basic_auth(
+            r#"
+                [tasks.test]
+                GET = "https://example.com/api/protected"
+
+                [tasks.test.auth.basic]
+                username = "admin"
+                password = "secret123"
+            "#,
+            vec!["req", "-f", "-", "--curl", "test"],
+            "with_basic_auth"
+        )]
+        #[case::with_simple_proxy(
+            r#"
+                [tasks.test]
+                GET = "https://example.com/api/data"
+
+                [tasks.test.config]
+                proxy = "http://proxy.example.com:8080"
+            "#,
+            vec!["req", "-f", "-", "--curl", "test"],
+            "with_simple_proxy"
+        )]
+        #[case::with_proxy_auth(
+            r#"
+                [tasks.test]
+                GET = "https://example.com/api/data"
+
+                [tasks.test.config.proxy]
+                url = "http://proxy.example.com:8080"
+                username = "proxy-user"
+                password = "proxy-pass"
+            "#,
+            vec!["req", "-f", "-", "--curl", "test"],
+            "with_proxy_auth"
+        )]
+        #[case::with_detailed_proxy(
+            r#"
+                [tasks.test]
+                GET = "https://example.com/api/data"
+
+                [tasks.test.config.proxy]
+                http = "http://http-proxy.example.com:8080"
+                https = "http://https-proxy.example.com:8443"
+            "#,
+            vec!["req", "-f", "-", "--curl", "test"],
+            "with_detailed_proxy"
+        )]
         fn test_curl_output(
             #[case] input: &str,
             #[case] args: Vec<&str>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -984,6 +984,31 @@ mod tests {
             vec!["req", "-f", "-", "--curl", "test"],
             "with_detailed_proxy"
         )]
+        #[case::with_detailed_proxy_http_url(
+            r#"
+                [tasks.test]
+                GET = "http://example.com/api/data"
+
+                [tasks.test.config.proxy]
+                http = "http://http-proxy.example.com:8080"
+                https = "http://https-proxy.example.com:8443"
+            "#,
+            vec!["req", "-f", "-", "--curl", "test"],
+            "with_detailed_proxy_http_url"
+        )]
+        #[case::with_proxy_special_chars(
+            r#"
+                [tasks.test]
+                GET = "https://example.com/api/data"
+
+                [tasks.test.config.proxy]
+                url = "http://proxy.example.com:8080"
+                username = "user's\\name"
+                password = "pass'word"
+            "#,
+            vec!["req", "-f", "-", "--curl", "test"],
+            "with_proxy_special_chars"
+        )]
         fn test_curl_output(
             #[case] input: &str,
             #[case] args: Vec<&str>,

--- a/src/snapshots/req__tests__curl_option_tests__post_with_json_body.snap
+++ b/src/snapshots/req__tests__curl_option_tests__post_with_json_body.snap
@@ -3,7 +3,7 @@ source: src/main.rs
 expression: output_str
 ---
 curl -X POST 'https://example.com/api/users' \
-	-H 'content-type:application/json' \
+	-H 'content-type: application/json' \
 	-d @- << REQUEST_BODY
 {"email":"john@example.com","name":"John Doe"}
 REQUEST_BODY

--- a/src/snapshots/req__tests__curl_option_tests__post_with_multiline_body.snap
+++ b/src/snapshots/req__tests__curl_option_tests__post_with_multiline_body.snap
@@ -3,7 +3,7 @@ source: src/main.rs
 expression: output_str
 ---
 curl -X POST 'https://example.com/api/data' \
-	-H 'content-type:application/json' \
+	-H 'content-type: application/json' \
 	-d @- << REQUEST_BODY
 {"description":"Line 1\nLine 2\nLine 3","title":"Test"}
 REQUEST_BODY

--- a/src/snapshots/req__tests__curl_option_tests__with_basic_auth.snap
+++ b/src/snapshots/req__tests__curl_option_tests__with_basic_auth.snap
@@ -1,0 +1,6 @@
+---
+source: src/main.rs
+expression: output_str
+---
+curl -X GET 'https://example.com/api/protected' \
+	-H 'authorization:Basic YWRtaW46c2VjcmV0MTIz'

--- a/src/snapshots/req__tests__curl_option_tests__with_basic_auth.snap
+++ b/src/snapshots/req__tests__curl_option_tests__with_basic_auth.snap
@@ -3,4 +3,4 @@ source: src/main.rs
 expression: output_str
 ---
 curl -X GET 'https://example.com/api/protected' \
-	-H 'authorization:Basic YWRtaW46c2VjcmV0MTIz'
+	-u 'admin:secret123'

--- a/src/snapshots/req__tests__curl_option_tests__with_bearer_auth.snap
+++ b/src/snapshots/req__tests__curl_option_tests__with_bearer_auth.snap
@@ -3,4 +3,4 @@ source: src/main.rs
 expression: output_str
 ---
 curl -X GET 'https://example.com/api/protected' \
-	-H 'authorization:Bearer my-secret-token-123'
+	-H 'authorization: Bearer my-secret-token-123'

--- a/src/snapshots/req__tests__curl_option_tests__with_bearer_auth.snap
+++ b/src/snapshots/req__tests__curl_option_tests__with_bearer_auth.snap
@@ -1,0 +1,6 @@
+---
+source: src/main.rs
+expression: output_str
+---
+curl -X GET 'https://example.com/api/protected' \
+	-H 'authorization:Bearer my-secret-token-123'

--- a/src/snapshots/req__tests__curl_option_tests__with_custom_headers.snap
+++ b/src/snapshots/req__tests__curl_option_tests__with_custom_headers.snap
@@ -3,5 +3,5 @@ source: src/main.rs
 expression: output_str
 ---
 curl -X GET 'https://example.com/api/users' \
-	-H 'authorization:Bearer token123' \
-	-H 'x-custom-header:custom-value'
+	-H 'authorization: Bearer token123' \
+	-H 'x-custom-header: custom-value'

--- a/src/snapshots/req__tests__curl_option_tests__with_detailed_proxy.snap
+++ b/src/snapshots/req__tests__curl_option_tests__with_detailed_proxy.snap
@@ -1,0 +1,6 @@
+---
+source: src/main.rs
+expression: output_str
+---
+curl -X GET 'https://example.com/api/data' \
+	-x 'http://https-proxy.example.com:8443'

--- a/src/snapshots/req__tests__curl_option_tests__with_detailed_proxy_http_url.snap
+++ b/src/snapshots/req__tests__curl_option_tests__with_detailed_proxy_http_url.snap
@@ -1,0 +1,6 @@
+---
+source: src/main.rs
+expression: output_str
+---
+curl -X GET 'http://example.com/api/data' \
+	-x 'http://http-proxy.example.com:8080'

--- a/src/snapshots/req__tests__curl_option_tests__with_proxy_auth.snap
+++ b/src/snapshots/req__tests__curl_option_tests__with_proxy_auth.snap
@@ -1,0 +1,7 @@
+---
+source: src/main.rs
+expression: output_str
+---
+curl -X GET 'https://example.com/api/data' \
+	-x 'http://proxy.example.com:8080' \
+	--proxy-user 'proxy-user:proxy-pass'

--- a/src/snapshots/req__tests__curl_option_tests__with_proxy_special_chars.snap
+++ b/src/snapshots/req__tests__curl_option_tests__with_proxy_special_chars.snap
@@ -1,0 +1,7 @@
+---
+source: src/main.rs
+expression: output_str
+---
+curl -X GET 'https://example.com/api/data' \
+	-x 'http://proxy.example.com:8080' \
+	--proxy-user 'user\'s\\name:pass\'word'

--- a/src/snapshots/req__tests__curl_option_tests__with_simple_proxy.snap
+++ b/src/snapshots/req__tests__curl_option_tests__with_simple_proxy.snap
@@ -1,0 +1,6 @@
+---
+source: src/main.rs
+expression: output_str
+---
+curl -X GET 'https://example.com/api/data' \
+	-x 'http://proxy.example.com:8080'


### PR DESCRIPTION
## Summary

Added comprehensive support for proxy and authentication configurations in the `--curl` output option.

### Changes

- **Proxy support**: Added `-x` and `--proxy-user` flags for proxy configurations
  - Simple proxy (single URL)
  - Authenticated proxy (with username/password)
  - Detailed proxy (separate HTTP/HTTPS proxies)
- **Authentication improvements**:
  - Bearer authentication: Uses `-H 'Authorization: Bearer ...'` header
  - Basic authentication: Uses `-u 'username:password'` option for better readability
- **Security**: Proper escaping of special characters in proxy credentials
- **Tests**: Added 7 new test cases covering various proxy and auth scenarios

### Test Coverage

New snapshot tests include:
- Bearer authentication
- Basic authentication
- Simple proxy
- Proxy with authentication
- Detailed proxy (HTTP/HTTPS)
- HTTP URL with detailed proxy
- Proxy credentials with special characters

## Test plan

- [x] All existing tests pass
- [x] New snapshot tests verify curl output format
- [x] Lint checks pass
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)